### PR TITLE
add list pattern matching exercise

### DIFF
--- a/src/Exercise024ListPatternMatching.elm
+++ b/src/Exercise024ListPatternMatching.elm
@@ -1,0 +1,87 @@
+module Exercise024ListPatternMatching exposing (..)
+
+import Browser
+import Html exposing (Html, button, div, img, text)
+import Html.Attributes exposing (src, style)
+import Html.Events exposing (onClick)
+
+
+type alias Model =
+    { shapes : List Shape }
+
+
+type Shape
+    = Square Float
+    | Circle Float
+
+
+initialModel : Model
+initialModel =
+    { shapes = [ Square 50 ] }
+
+
+type Msg
+    = AddShape Shape
+    | RemoveShape
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        AddShape shape ->
+            { model | shapes = shape :: model.shapes }
+
+        RemoveShape ->
+            case model.shapes of
+                firstShape :: otherShapes ->
+                    { model | shapes = otherShapes }
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ div []
+            [ button [ onClick (AddShape (Square 50)), style "margin-right" "1em" ] [ text "Ajouter un carré" ]
+            , button [ onClick (AddShape (Circle 50)), style "margin-right" "1em" ] [ text "Ajouter un cercle" ]
+            , button [ onClick RemoveShape ] [ text "Supprimer la dernière forme" ]
+            ]
+        , div [ style "padding" "1rem", style "display" "flex" ]
+            (List.map viewShape model.shapes)
+        ]
+
+
+viewShape : Shape -> Html Msg
+viewShape shape =
+    case shape of
+        Square side ->
+            div
+                [ style "width" (floatToPixels side)
+                , style "height" (floatToPixels side)
+                , style "background-color" "blue"
+                , style "margin-right" "1em"
+                ]
+                []
+
+        Circle radius ->
+            div
+                [ style "width" (floatToPixels radius)
+                , style "height" (floatToPixels radius)
+                , style "background-color" "green"
+                , style "border-radius" "50%"
+                , style "margin-right" "1em"
+                ]
+                []
+
+
+floatToPixels : Float -> String
+floatToPixels float =
+    String.fromFloat float ++ "px"
+
+
+main : Program () Model Msg
+main =
+    Browser.sandbox
+        { init = initialModel
+        , view = view
+        , update = update
+        }

--- a/src/Exercise025Http.elm
+++ b/src/Exercise025Http.elm
@@ -1,4 +1,4 @@
-module Exercise024Http exposing (..)
+module Exercise025Http exposing (..)
 
 import Browser
 import Html exposing (Html, button, div, img, pre, text)

--- a/src/Exercise026HttpDecoder.elm
+++ b/src/Exercise026HttpDecoder.elm
@@ -1,4 +1,4 @@
-module Exercise025HttpDecoder exposing (..)
+module Exercise026HttpDecoder exposing (..)
 
 import Browser
 import Html exposing (..)

--- a/src/Exercise027Time.elm
+++ b/src/Exercise027Time.elm
@@ -1,4 +1,4 @@
-module Exercise026Time exposing (..)
+module Exercise027Time exposing (..)
 
 import Browser
 import Html exposing (..)


### PR DESCRIPTION
## Pourquoi ?

Pour l'exercice "draw" où il faut enlever un élément de la liste, on a besoin du pattern matching sur les listes et on ne montre ça nul part ailleurs. 

ça permet en plus d'illustrer "en Elm, t'es obligé de gérer le cas "liste vide", tu peux pas te prendre un "null pointer exception" :D .

Si @jgrenat  ça te va, je change les numérotations des exercices d'après et je merge.
